### PR TITLE
Fix async scrapers to actually run in thread pool

### DIFF
--- a/scheduled_scraper.py
+++ b/scheduled_scraper.py
@@ -46,7 +46,7 @@ async def main():
         logger.info(f"Found {len(isbns)} ISBNs to scrape")
         
         # Log ISBN details
-        for isbn, metadata in isbns.items():
+        for title, isbn, metadata in isbns:
             title = metadata.get('title', 'Unknown Title')
             logger.info(f"  - {isbn}: {title}")
         


### PR DESCRIPTION
## Summary
- run Selenium calls in a shared `ThreadPoolExecutor`
- update async scraper functions to offload blocking work to executor
- remove duplicate `scrape_abebooks_async` implementation
- restore missing sync wrapper for AbeBooks

## Testing
- `python test_suite.py` *(fails: 5 passed, 1 failed)*

------
https://chatgpt.com/codex/tasks/task_b_6849a2b22fe0832ca69aa93a54eaa794